### PR TITLE
Fix PHPCS linting workflow and errors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,6 +18,13 @@ jobs:
 
       - uses: actions/checkout@v1
 
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          coverage: none
+          tools: composer
+
       - name: Validate composer.json and composer.lock
         run: composer validate
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,14 +16,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: '7.4'
           coverage: none
-          tools: composer
+          tools: composer, cs2pr
 
       - name: Validate composer.json and composer.lock
         run: composer validate

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "firebase/php-jwt",
-            "version": "v5.2.0",
+            "version": "v5.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/firebase/php-jwt.git",
-                "reference": "feb0e820b8436873675fd3aca04f3728eb2185cb"
+                "reference": "83b609028194aa042ea33b5af2d41a7427de80e6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/feb0e820b8436873675fd3aca04f3728eb2185cb",
-                "reference": "feb0e820b8436873675fd3aca04f3728eb2185cb",
+                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/83b609028194aa042ea33b5af2d41a7427de80e6",
+                "reference": "83b609028194aa042ea33b5af2d41a7427de80e6",
                 "shasum": ""
             },
             "require": {
@@ -25,6 +25,9 @@
             },
             "require-dev": {
                 "phpunit/phpunit": ">=4.8 <=9"
+            },
+            "suggest": {
+                "paragonie/sodium_compat": "Support EdDSA (Ed25519) signatures when libsodium is not present"
             },
             "type": "library",
             "autoload": {
@@ -54,7 +57,11 @@
                 "jwt",
                 "php"
             ],
-            "time": "2020-03-25T18:49:23+00:00"
+            "support": {
+                "issues": "https://github.com/firebase/php-jwt/issues",
+                "source": "https://github.com/firebase/php-jwt/tree/v5.5.1"
+            },
+            "time": "2021-11-08T20:18:51+00:00"
         }
     ],
     "packages-dev": [
@@ -97,27 +104,27 @@
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v0.6.2",
+            "version": "v0.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
-                "reference": "8001af8eb107fbfcedc31a8b51e20b07d85b457a"
+                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/8001af8eb107fbfcedc31a8b51e20b07d85b457a",
-                "reference": "8001af8eb107fbfcedc31a8b51e20b07d85b457a",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
+                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0",
-                "php": "^5.3|^7",
-                "squizlabs/php_codesniffer": "^2|^3"
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
             },
             "require-dev": {
                 "composer/composer": "*",
-                "phpcompatibility/php-compatibility": "^9.0",
-                "sensiolabs/security-checker": "^4.1.0"
+                "php-parallel-lint/php-parallel-lint": "^1.3.1",
+                "phpcompatibility/php-compatibility": "^9.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -138,6 +145,10 @@
                     "email": "franck.nijhof@dealerdirect.com",
                     "homepage": "http://www.frenck.nl",
                     "role": "Developer / IT Manager"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
@@ -149,6 +160,7 @@
                 "codesniffer",
                 "composer",
                 "installer",
+                "phpcbf",
                 "phpcs",
                 "plugin",
                 "qa",
@@ -159,7 +171,11 @@
                 "stylecheck",
                 "tests"
             ],
-            "time": "2020-01-29T20:22:20+00:00"
+            "support": {
+                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
+                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+            },
+            "time": "2022-02-04T12:51:07+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",
@@ -217,32 +233,36 @@
                 "phpcs",
                 "standards"
             ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibility/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibility"
+            },
             "time": "2019-12-27T09:44:58+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-paragonie",
-            "version": "1.3.0",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
-                "reference": "b862bc32f7e860d0b164b199bd995e690b4b191c"
+                "reference": "ddabec839cc003651f2ce695c938686d1086cf43"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/b862bc32f7e860d0b164b199bd995e690b4b191c",
-                "reference": "b862bc32f7e860d0b164b199bd995e690b4b191c",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/ddabec839cc003651f2ce695c938686d1086cf43",
+                "reference": "ddabec839cc003651f2ce695c938686d1086cf43",
                 "shasum": ""
             },
             "require": {
                 "phpcompatibility/php-compatibility": "^9.0"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
                 "paragonie/random_compat": "dev-master",
                 "paragonie/sodium_compat": "dev-master"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
                 "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
             },
             "type": "phpcodesniffer-standard",
@@ -269,20 +289,24 @@
                 "polyfill",
                 "standards"
             ],
-            "time": "2019-11-04T15:17:54+00:00"
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie"
+            },
+            "time": "2021-02-15T10:24:51+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-wp",
-            "version": "2.1.0",
+            "version": "2.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
-                "reference": "41bef18ba688af638b7310666db28e1ea9158b2f"
+                "reference": "d55de55f88697b9cdb94bccf04f14eb3b11cf308"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/41bef18ba688af638b7310666db28e1ea9158b2f",
-                "reference": "41bef18ba688af638b7310666db28e1ea9158b2f",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/d55de55f88697b9cdb94bccf04f14eb3b11cf308",
+                "reference": "d55de55f88697b9cdb94bccf04f14eb3b11cf308",
                 "shasum": ""
             },
             "require": {
@@ -290,10 +314,10 @@
                 "phpcompatibility/phpcompatibility-paragonie": "^1.0"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
                 "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
             },
             "type": "phpcodesniffer-standard",
@@ -319,20 +343,24 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2019-08-28T14:22:28+00:00"
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityWP/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
+            },
+            "time": "2021-12-30T16:37:40+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.4",
+            "version": "3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "dceec07328401de6211037abbb18bda423677e26"
+                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/dceec07328401de6211037abbb18bda423677e26",
-                "reference": "dceec07328401de6211037abbb18bda423677e26",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619",
                 "shasum": ""
             },
             "require": {
@@ -370,20 +398,25 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2020-01-30T22:20:29+00:00"
+            "support": {
+                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
+                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
+                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+            },
+            "time": "2022-06-18T07:21:10+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "2.2.1",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "b5a453203114cc2284b1a614c4953456fbe4f546"
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/b5a453203114cc2284b1a614c4953456fbe4f546",
-                "reference": "b5a453203114cc2284b1a614c4953456fbe4f546",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7da1894633f168fe244afc6de00d141f27517b62",
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62",
                 "shasum": ""
             },
             "require": {
@@ -393,6 +426,7 @@
             "require-dev": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
                 "phpcompatibility/php-compatibility": "^9.0",
+                "phpcsstandards/phpcsdevtools": "^1.0",
                 "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "suggest": {
@@ -415,7 +449,12 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2020-02-04T02:52:06+00:00"
+            "support": {
+                "issues": "https://github.com/WordPress/WordPress-Coding-Standards/issues",
+                "source": "https://github.com/WordPress/WordPress-Coding-Standards",
+                "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
+            },
+            "time": "2020-05-13T23:57:56+00:00"
         }
     ],
     "aliases": [],
@@ -424,5 +463,6 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "2.1.0"
 }

--- a/inc/class-admin.php
+++ b/inc/class-admin.php
@@ -101,7 +101,7 @@ class Admin {
 	 */
 	public function add_scripts( $hook ) {
 
-		wp_register_script( 'maestro', MAESTRO_URL . 'assets/js/maestro.js', array( 'jquery' ), MAESTRO_VERSION );
+		wp_register_script( 'maestro', MAESTRO_URL . 'assets/js/maestro.js', array( 'jquery' ), MAESTRO_VERSION, false );
 		$data = array(
 			'urls'    => array(
 				'site'        => get_option( 'siteurl' ),
@@ -112,7 +112,7 @@ class Admin {
 				'maestroPage' => add_query_arg( 'page', 'bluehost-maestro', admin_url( 'users.php' ) ),
 			),
 			'nonces'  => array(
-				'ajax' => wp_create_nonce( 'maestro_check_key' )
+				'ajax' => wp_create_nonce( 'maestro_check_key' ),
 			),
 			'strings' => $this->get_translated_strings(),
 		);
@@ -120,7 +120,7 @@ class Admin {
 
 		// Only add specific assets to the add-maestro page
 		if ( $this->page_hook === $hook ) {
-			wp_enqueue_style( 'google-open-sans', 'https://fonts.googleapis.com/css?family=Open+Sans:300,400,600&display=swap', array() );
+			wp_enqueue_style( 'google-open-sans', 'https://fonts.googleapis.com/css?family=Open+Sans:300,400,600&display=swap', array(), MAESTRO_VERSION );
 			wp_enqueue_style( 'maestro', MAESTRO_URL . 'assets/css/bh-maestro.css', array( 'google-open-sans' ), MAESTRO_VERSION );
 			wp_enqueue_script( 'maestro' );
 		}
@@ -138,14 +138,16 @@ class Admin {
 		?>
 		<div class="wrap maestro-container">
 			<div class="maestro-page">
-				<img class="logo" src="<?php echo MAESTRO_URL . 'assets/images/bh-maestro-logo.svg'; ?>" />
+				<img class="logo" src="<?php echo esc_url( MAESTRO_URL . 'assets/images/bh-maestro-logo.svg' ); ?>" />
 				<div class="maestro-content">
 					<?php
 					$compatible = $this->check_requirements();
 					if ( true !== $compatible ) {
 						include $this->partials . 'requirements.php';
+					// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 					} elseif ( isset( $_GET['action'] ) && 'revoke' === $_GET['action'] ) {
 						$this->confirm_revoke( $nonce, $id );
+					// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 					} elseif ( isset( $_GET['action'] ) && 'dorevoke' === $_GET['action'] ) {
 						$this->revoke( $nonce, $id );
 					} else {
@@ -170,14 +172,14 @@ class Admin {
 	public function confirm_revoke( $nonce, $id ) {
 
 		if ( 1 !== wp_verify_nonce( $nonce, 'revoke-webpro' ) ) {
-			echo '<p class="thin">' . __( 'Unable to complete your request. Please try again.', 'maestro-connector' ) . '</p>';
+			echo '<p class="thin">' . esc_html__( 'Unable to complete your request. Please try again.', 'maestro-connector' ) . '</p>';
 			return;
 		}
 
 		try {
 			$webpro = new Web_Pro( $id );
 		} catch ( Exception $e ) {
-			echo '<p class="thin">' . __( 'Invalid user ID.', 'maestro-connector' ) . '</p>';
+			echo '<p class="thin">' . esc_html__( 'Invalid user ID.', 'maestro-connector' ) . '</p>';
 		}
 
 		if ( $webpro->is_connected() ) {
@@ -191,7 +193,7 @@ class Admin {
 			$cancel_url  = add_query_arg( 'page', 'bluehost-maestro', admin_url( 'users.php' ) );
 			include $this->partials . 'confirm-revoke.php';
 		} else {
-			echo '<p class="thin">' . __( 'This user is not a connected Web Pro.', 'maestro-connector' ) . '</p>';
+			echo '<p class="thin">' . esc_html__( 'This user is not a connected Web Pro.', 'maestro-connector' ) . '</p>';
 		}
 	}
 
@@ -205,22 +207,22 @@ class Admin {
 	 */
 	public function revoke( $nonce, $id ) {
 		if ( 1 !== wp_verify_nonce( $nonce, 'confirm-revoke-webpro' ) ) {
-			echo '<p class="thin">' . __( 'Unable to complete your request. Please try again.', 'maestro-connector' ) . '</p>';
+			echo '<p class="thin">' . esc_html__( 'Unable to complete your request. Please try again.', 'maestro-connector' ) . '</p>';
 			return;
 		}
 
 		try {
 			$webpro = new Web_Pro( $id );
 		} catch ( Exception $e ) {
-			echo '<p class="thin">' . __( 'Invalid user ID.', 'maestro-connector' ) . '</p>';
+			echo '<p class="thin">' . esc_html__( 'Invalid user ID.', 'maestro-connector' ) . '</p>';
 		}
 
 		$webpro->disconnect();
 
 		if ( ! $webpro->is_connected() ) {
-			echo '<p class="thin">' . __( 'The Maestro connection for this Web Pro has been revoked and their user role has been demoted.', 'maestro-connector' ) . '</p>';
+			echo '<p class="thin">' . esc_html__( 'The Maestro connection for this Web Pro has been revoked and their user role has been demoted.', 'maestro-connector' ) . '</p>';
 		} else {
-			echo '<p class="thin">' . __( 'Something went wrong. Please try again.', 'maestro-connector' ) . '</p>';
+			echo '<p class="thin">' . esc_html__( 'Something went wrong. Please try again.', 'maestro-connector' ) . '</p>';
 		}
 	}
 

--- a/inc/class-encryption.php
+++ b/inc/class-encryption.php
@@ -2,6 +2,9 @@
 
 namespace Bluehost\Maestro;
 
+/**
+ * Simple encryption/decription class for storing tokens
+ */
 class Encryption {
 
 	/**
@@ -109,6 +112,7 @@ class Encryption {
 			return false;
 		}
 
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 		return base64_encode( $iv . $cipher );
 	}
 
@@ -128,6 +132,7 @@ class Encryption {
 			return $cipher;
 		}
 
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
 		$cipher = base64_decode( $cipher, true );
 
 		// Grab the IV from the front of the passed encrypted string

--- a/inc/class-token.php
+++ b/inc/class-token.php
@@ -61,11 +61,10 @@ class Token {
 	 *
 	 * @since 1.0
 	 *
-	 * @param Web_Pro $webpro      The web pro object for whom the token is issued
-	 * @param int     $user_id     The ID of the user the token is issued for
-	 * @param int     $expires     Unix timestamp representing time the token expires (optional)
-	 * @param bool    $jti         Generate a unique identifier which makes this a single-use token (optional)
-	 * @param array   $data        Array of additional data to encode into the token (optional)
+	 * @param Web_Pro $webpro  The web pro object for whom the token is issued
+	 * @param int     $expires Unix timestamp representing time the token expires (optional)
+	 * @param bool    $jti     Generate a unique identifier which makes this a single-use token (optional)
+	 * @param array   $data    Array of additional data to encode into the token (optional)
 	 *
 	 * @return string|WP_Error
 	 */
@@ -104,9 +103,9 @@ class Token {
 	/**
 	 * Compile information for the the JWT token.
 	 *
-	 * @param int             $expires    The number of seconds until the token expires.
-	 * @param string          $jti        Optional unique identifier string. Forces token to be single-use.
-	 * @param array           $extra_data Optional array of additional data to encode into the data portion of the token
+	 * @param int    $expires    The number of seconds until the token expires.
+	 * @param string $jti        Optional unique identifier string. Forces token to be single-use.
+	 * @param array  $extra_data Optional array of additional data to encode into the data portion of the token
 	 *
 	 * @return array|WP_Error
 	 */
@@ -282,7 +281,7 @@ class Token {
 	 *
 	 * @since 1.0
 	 *
-	 * @param object  $token The decoded token.
+	 * @param object $token The decoded token.
 	 *
 	 * @return bool|WP_Error
 	 */

--- a/inc/class-web-pro.php
+++ b/inc/class-web-pro.php
@@ -116,6 +116,8 @@ class Web_Pro {
 	 *
 	 * @param int    $user_id The ID of a WordPress user
 	 * @param string $key     A connection key assigned to a Web Pro by the platform
+	 *
+	 * @throws Exception Unable to retrieve WebPro.
 	 */
 	public function __construct( $user_id = 0, $key = '' ) {
 
@@ -197,6 +199,8 @@ class Web_Pro {
 	 * Fetches details about the web pro from the Maestro platform using the provided key
 	 *
 	 * @since 1.0
+	 *
+	 * @param string $key The magic key to send to Maestro platform
 	 */
 	private function fetch_details( $key ) {
 		$data = $this->verify_key( $key );
@@ -211,7 +215,9 @@ class Web_Pro {
 	 *
 	 * @since 1.0
 	 *
-	 * @return array|false Array of data if valid, false if key is invalid
+	 * @param string $key The magic key to send to Maestro platform
+	 *
+	 * @return object|false Plan object containing data if valid, false if key is invalid
 	 */
 	private function verify_key( $key ) {
 
@@ -245,8 +251,7 @@ class Web_Pro {
 	 *
 	 * @since 1.0
 	 *
-	 * @param array $data The array of data returned from verifying the key on the platform
-	 *
+	 * @param object $data The data returned from verifying the key on the platform
 	 */
 	private function parse_platform_response( $data ) {
 		// We might have an existing user that matches the email
@@ -274,6 +279,8 @@ class Web_Pro {
 	 * @since 1.0
 	 *
 	 * @return int|false The user ID of the user who is connected, or false if the connection failed
+	 *
+	 * @throws Exception Cannot connect WebPro.
 	 */
 	public function connect() {
 
@@ -356,7 +363,7 @@ class Web_Pro {
 				$this->clean_up();
 			} else {
 				// Otherwise just remove them
-				require_once( ABSPATH . 'wp-admin/includes/user.php' );
+				require_once ABSPATH . 'wp-admin/includes/user.php';
 				wp_delete_user( $this->user->ID );
 			}
 			return false;
@@ -488,14 +495,14 @@ class Web_Pro {
 	 *
 	 * @since 1.0
 	 *
-	 * @param bool Whether to check for the platform revoke token or not
+	 * @param bool $check_revoke Whether to check for the platform revoke token or not
 	 *
 	 * @return bool Connected or not
 	 */
 	public function is_connected( $check_revoke = true ) {
 		// To generally be considered connected, we need:
-		//     - A key submitted by a site administrator
-		//     - A revoke token saved in usermeta returned from the platform
+		// - A key submitted by a site administrator
+		// - A revoke token saved in usermeta returned from the platform
 		if ( $this->get_key() && $this->user ) {
 			// Allows bypassing the revoke token check when required
 			if ( $check_revoke ) {

--- a/inc/partials/add.php
+++ b/inc/partials/add.php
@@ -1,10 +1,10 @@
 <div class="message">
-	<p class="thin"><?php _e( 'Your web professional shared a secret key with you. By entering the key below, you\'re giving them administrative access to your WordPress website. Revoke access at any time.', 'maestro-connector' ); ?></p>
+	<p class="thin"><?php esc_html_e( 'Your web professional shared a secret key with you. By entering the key below, you\'re giving them administrative access to your WordPress website. Revoke access at any time.', 'maestro-connector' ); ?></p>
 </div>
 <div class="details bold"></div>
 <div class="actions">
 	<form method="POST" action="" class="maestro-key-form">
-		<input type="text" name="key" class="key" placeholder="<?php _e( 'Enter secret key here', 'maestro-connector' ); ?>" />
-		<button class="maestro-button primary submit" disabled><span class="next"><?php _e( 'Next', 'maestro-connector' ); ?></span></button>
+		<input type="text" name="key" class="key" placeholder="<?php esc_html_e( 'Enter secret key here', 'maestro-connector' ); ?>" />
+		<button class="maestro-button primary submit" disabled><span class="next"><?php esc_html_e( 'Next', 'maestro-connector' ); ?></span></button>
 	</form>
 </div>

--- a/inc/partials/confirm-revoke.php
+++ b/inc/partials/confirm-revoke.php
@@ -1,9 +1,9 @@
-<p class="thin"><?php _e( 'Are you sure you would like to revoke access for this Web Pro?', 'maestro-connector' ); ?></p>
+<p class="thin"><?php esc_html_e( 'Are you sure you would like to revoke access for this Web Pro?', 'maestro-connector' ); ?></p>
 <div class="details bold">
-	<div class='name'><span><?php _e( 'Name', 'maestro-connector' ); ?>:</span> <span><?php echo esc_html( $webpro->user->first_name ); ?> <?php echo esc_html( $webpro->user->last_name ); ?></span></div>
-	<div class='email'><span><?php _e( 'Email', 'maestro-connector' ); ?>:</span> <span><?php echo esc_html( $webpro->user->user_email ); ?></span></div>
+	<div class='name'><span><?php esc_html_e( 'Name', 'maestro-connector' ); ?>:</span> <span><?php echo esc_html( $webpro->user->first_name ); ?> <?php echo esc_html( $webpro->user->last_name ); ?></span></div>
+	<div class='email'><span><?php esc_html_e( 'Email', 'maestro-connector' ); ?>:</span> <span><?php echo esc_html( $webpro->user->useresc_html_email ); ?></span></div>
 </div>
 <div class="buttons">
-	<a href="<?php echo $cancel_url; ?>" class="maestro-button secondary"><?php _e( 'No, leave them', 'maestro-connector' ); ?></a>
-	<a href="<?php echo $confirm_url; ?>" class="maestro-button primary"><?php _e( 'Yes, revoke access', 'maestro-connector' ); ?></a>
+	<a href="<?php echo esc_url( $cancel_url ); ?>" class="maestro-button secondary"><?php esc_html_e( 'No, leave them', 'maestro-connector' ); ?></a>
+	<a href="<?php echo esc_url( $confirm_url ); ?>" class="maestro-button primary"><?php esc_html_e( 'Yes, revoke access', 'maestro-connector' ); ?></a>
 </div>

--- a/inc/partials/confirm-revoke.php
+++ b/inc/partials/confirm-revoke.php
@@ -1,7 +1,7 @@
 <p class="thin"><?php esc_html_e( 'Are you sure you would like to revoke access for this Web Pro?', 'maestro-connector' ); ?></p>
 <div class="details bold">
 	<div class='name'><span><?php esc_html_e( 'Name', 'maestro-connector' ); ?>:</span> <span><?php echo esc_html( $webpro->user->first_name ); ?> <?php echo esc_html( $webpro->user->last_name ); ?></span></div>
-	<div class='email'><span><?php esc_html_e( 'Email', 'maestro-connector' ); ?>:</span> <span><?php echo esc_html( $webpro->user->useresc_html_email ); ?></span></div>
+	<div class='email'><span><?php esc_html_e( 'Email', 'maestro-connector' ); ?>:</span> <span><?php echo esc_html( $webpro->user->user_email ); ?></span></div>
 </div>
 <div class="buttons">
 	<a href="<?php echo esc_url( $cancel_url ); ?>" class="maestro-button secondary"><?php esc_html_e( 'No, leave them', 'maestro-connector' ); ?></a>

--- a/inc/partials/requirements.php
+++ b/inc/partials/requirements.php
@@ -1,5 +1,5 @@
 <p class="thin">
-	<?php _e( 'We\'re sorry, but your site is not compatible with the Maestro plugin.', 'maestro-connector' ); ?>
+	<?php esc_html_e( 'We\'re sorry, but your site is not compatible with the Maestro plugin.', 'maestro-connector' ); ?>
 </p>
 <p class="thin error">
 	<?php echo esc_html( $compatible->get_error_message() ); ?>

--- a/inc/partials/user-profile-section.php
+++ b/inc/partials/user-profile-section.php
@@ -1,17 +1,17 @@
-<h2><?php _e( 'Bluehost Maestro', 'maestro-connector' ); ?></h2>
+<h2><?php esc_html_e( 'Bluehost Maestro', 'maestro-connector' ); ?></h2>
 <table class="form-table" role="presentation">
 	<tbody>
 		<tr class="user-maestro-added-date">
-			<th><?php _e( 'Date Added', 'maestro-connector' ); ?></th>
+			<th><?php esc_html_e( 'Date Added', 'maestro-connector' ); ?></th>
 			<td><?php echo esc_html( gmdate( get_option( 'date_format' ), (int) $webpro->added_time ) ); ?></td>
 		</tr>
 		<tr class="user-maestro-added-by">
-			<th><?php _e( 'Added By', 'maestro-connector' ); ?></th>
+			<th><?php esc_html_e( 'Added By', 'maestro-connector' ); ?></th>
 			<td><?php echo esc_html( $webpro->added_by ); ?></td>
 		</tr>
 		<tr class="user-maestro-revoke">
-			<th><?php _e( 'Revoke', 'maestro-connector' ); ?></th>
-			<td><a href="<?php echo $revoke_url; ?>" class="button button-secondary"><?php _e( 'Revoke Maestro Access', 'maestro-connector' ); ?></a></td>
+			<th><?php esc_html_e( 'Revoke', 'maestro-connector' ); ?></th>
+			<td><a href="<?php echo esc_url( $revoke_url ); ?>" class="button button-secondary"><?php esc_html_e( 'Revoke Maestro Access', 'maestro-connector' ); ?></a></td>
 		</tr>
 	</tbody>
 </table>

--- a/inc/rest-api/class-rest-api.php
+++ b/inc/rest-api/class-rest-api.php
@@ -2,8 +2,14 @@
 
 namespace Bluehost\Maestro;
 
+/**
+ * Primary class for loading REST API endpoints and handling authentication
+ */
 class REST_API {
 
+	/**
+	 * Constructor
+	 */
 	public function __construct() {
 
 		$this->register_routes();
@@ -37,7 +43,7 @@ class REST_API {
 	 *
 	 * @since 1.0
 	 *
-	 * @param mixed $result Result of any other authentication attempts
+	 * @param mixed $status Result of any other authentication attempts
 	 *
 	 * @return WP_Error|null|bool
 	 */
@@ -80,7 +86,7 @@ class REST_API {
 	 *
 	 * @return null|string The token from the header or null
 	 */
-	function get_access_token() {
+	public function get_access_token() {
 		$token = null;
 		if ( ! empty( $_SERVER['HTTP_MAESTRO_AUTHORIZATION'] ) ) {
 			$token = wp_unslash( $_SERVER['HTTP_MAESTRO_AUTHORIZATION'] );

--- a/inc/rest-api/class-rest-webpros-controller.php
+++ b/inc/rest-api/class-rest-webpros-controller.php
@@ -435,7 +435,8 @@ class REST_Webpros_Controller extends \WP_REST_Controller {
 	 *
 	 * @since 1.0
 	 *
-	 * @param int $id Supplied ID.
+	 * @param int     $id Supplied ID.
+	 * @param boolean $check_revoke Whether to check for the Maestro revoke token
 	 *
 	 * @return Web_Pro|WP_Error Web_Pro object if ID is valid, WP_Error otherwise.
 	 */

--- a/inc/sso.php
+++ b/inc/sso.php
@@ -2,7 +2,6 @@
 
 namespace Bluehost\Maestro;
 
-
 // Ajax hooks for SSO
 add_action( 'wp_ajax_nopriv_bh-maestro-sso', __NAMESPACE__ . '\\authenticate_sso' );
 add_action( 'wp_ajax_bh-maestro-sso', __NAMESPACE__ . '\\authenticate_sso' );
@@ -40,7 +39,7 @@ function authenticate_sso() {
 		failed_sso_attempts( 1 );
 		do_action( 'bh_maestro_sso_fail' );
 		wp_die(
-			__( 'Invalid token.', 'maestro-connector' ),
+			esc_html__( 'Invalid token.', 'maestro-connector' ),
 			403
 		);
 	}

--- a/maestro-connector.php
+++ b/maestro-connector.php
@@ -115,3 +115,5 @@ function vendor_notice() {
 	</tr>
 	<?php
 }
+
+// Temporary change to test PHP linting workflow

--- a/maestro-connector.php
+++ b/maestro-connector.php
@@ -31,9 +31,12 @@ if ( ! is_readable( __DIR__ . '/vendor/autoload.php' ) ) {
 require __DIR__ . '/vendor/autoload.php';
 
 // Load translations
-add_action( 'plugins_loaded', function () {
-	load_plugin_textdomain( basename( __DIR__ ), false, basename( __DIR__ ) . '/languages/' );
-} );
+add_action(
+	'plugins_loaded',
+	function () {
+		load_plugin_textdomain( basename( __DIR__ ), false, basename( __DIR__ ) . '/languages/' );
+	}
+);
 
 // Other required files
 require __DIR__ . '/inc/sso.php';
@@ -56,7 +59,9 @@ add_action( 'rest_api_init', __NAMESPACE__ . '\\rest_init' );
 function activate() {
 	// Don't do redirects when multiple plugins are bulk activated
 	if (
+		// phpcs:ignore WordPress.Security.NonceVerification
 		( isset( $_REQUEST['action'] ) && 'activate-selected' === $_REQUEST['action'] ) &&
+		// phpcs:ignore WordPress.Security.NonceVerification
 		( isset( $_POST['checked'] ) && count( $_POST['checked'] ) > 1 ) ) {
 		return;
 	}
@@ -99,6 +104,11 @@ function rest_init() {
 	$rest_api = new REST_API();
 }
 
+/**
+ * Displays warning message if dependencies have not been installed
+ *
+ * @return void
+ */
 function vendor_notice() {
 	?>
 	<style type="text/css">
@@ -109,11 +119,9 @@ function vendor_notice() {
 	</style>
 	<tr class="active maestro-warning">
 		<td colspan="3">
-			<strong style="color:#dc3232;"><span class="dashicons dashicons-warning"></span> <?php _e( 'Maestro is missing critical files', 'maestro-connector' ); ?></strong>
-			// <span><a href="https://www.bluehost.com/contact"><?php _e( 'Contact Bluehost Support', 'maestro-connector' ); ?> <span class="dashicons dashicons-external"></span> </a></span>
+			<strong style="color:#dc3232;"><span class="dashicons dashicons-warning"></span> <?php esc_html_e( 'Maestro is missing critical files', 'maestro-connector' ); ?></strong>
+			// <span><a href="https://www.bluehost.com/contact"><?php esc_html_e( 'Contact Bluehost Support', 'maestro-connector' ); ?> <span class="dashicons dashicons-external"></span> </a></span>
 		</td>
 	</tr>
 	<?php
 }
-
-// Temporary change to test PHP linting workflow


### PR DESCRIPTION
Changed the Lint workflow to use PHP 7.4 so that it could correctly resolve the dev dependencies for PHP linting. 

I also fixed all of the PHPCS errors that will inevitably come up from any PRs after this change is merged. 