### PR TITLE
Fix GitHub Action deprecated notices.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Get Composer Cache Directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer vendor directory
         uses: actions/cache@v1

--- a/.github/workflows/satis-webhook.yml
+++ b/.github/workflows/satis-webhook.yml
@@ -15,11 +15,11 @@ jobs:
         id: package
         env:
           REPO: ${{ github.repository }}
-        run: echo ::set-output name=PACKAGE::${REPO##*/}
+        run: echo "PACKAGE=${REPO##*/}" >> $GITHUB_OUTPUT
 
       - name: Set Version
         id: tag
-        run: echo ::set-output name=VERSION::${GITHUB_REF##*/}
+        run: echo "VERSION=${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
 
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v1

--- a/.github/workflows/upload-artifact-on-push.yml
+++ b/.github/workflows/upload-artifact-on-push.yml
@@ -18,7 +18,7 @@ jobs:
         id: package
         env:
           REPO: ${{ github.repository }}
-        run: echo ::set-output name=PACKAGE::${REPO##*/}
+        run: echo "PACKAGE=${REPO##*/}" >> $GITHUB_OUTPUT
 
       - name: PHP version
         run: php --version
@@ -36,7 +36,7 @@ jobs:
 
       - name: Get npm cache directory
         id: npm-cache
-        run: echo "::set-output name=dir::$(npm config get cache)"
+        run: echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
 
       - name: Cache node modules
         uses: actions/cache@v1
@@ -57,7 +57,7 @@ jobs:
 
       - name: Get Composer Cache Directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer vendor directory
         uses: actions/cache@v1

--- a/.github/workflows/upload-asset-on-release.yml
+++ b/.github/workflows/upload-asset-on-release.yml
@@ -19,7 +19,7 @@ jobs:
         id: package
         env:
           REPO: ${{ github.repository }}
-        run: echo ::set-output name=PACKAGE::${REPO##*/}
+        run: echo "PACKAGE=${REPO##*/}" >> $GITHUB_OUTPUT
 
       - name: PHP version
         run: php --version
@@ -37,7 +37,7 @@ jobs:
 
       - name: Get npm cache directory
         id: npm-cache
-        run: echo "::set-output name=dir::$(npm config get cache)"
+        run: echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
 
       - name: Cache node modules
         uses: actions/cache@v1
@@ -58,7 +58,7 @@ jobs:
 
       - name: Get Composer Cache Directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer vendor directory
         uses: actions/cache@v1


### PR DESCRIPTION
This fixes several deprecated notices caused by the use of `set-output` and `save-output` in GitHub Action workflows.

These were deprecated, and could be removed at any time without notice. GitHub posted an update on July 24th that they still plan on removing these commands but were delaying the removal because of continued high usage.

More can be found about this in the announcement posts:
- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/